### PR TITLE
Added adapt_args function decorator.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+venv/
+venv352/
 build/
 develop-eggs/
 dist/

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,11 @@ python:
   - 3.4
   - 3.5
   - 3.6
+  - 3.7
 sudo: false
 
 install:
   - pip install -r requirements_dev.txt
 
 script:
-  - python -m unittest discover
+  - python -m unittest discover -p test*

--- a/README.rst
+++ b/README.rst
@@ -421,6 +421,31 @@ get_interface_attribute_names(interface)
     if interface is not a ``PureInterface`` subtype then an empty set is returned
 
 
+Automatic Adaption
+==================
+The function decorator ``adapt_args`` adapts arguments to a decorated function to the types given.
+For example::
+
+    @adapt_args(foo=IFoo, bar=IBar)
+    def my_func(foo, bar=None):
+        pass
+
+In Python 3.5 and later the types can be taken from the argument annotations.::
+
+    @adapt_args
+    def my_func(foo: IFoo, bar: IBar=None):
+        pass
+
+This would adapt the ``foo`` parameter to ``IFoo`` (with ``IFoo.optional_adapt(foo))`` and ``bar`` to ``IBar
+(using ``IBar.optional_adapt(bar)``)
+before passing them to my_func.  ``None`` values are never adapted, so ``my_func(foo, None)`` will work, otherwise
+``ValueError`` is raised if the parameter is not adaptable.
+All arguments must be specified as keyword arguments::
+
+    @adapt_args(IFoo, IBar)   # NOT ALLOWED
+    def other_func(foo, bar):
+        pass
+
 Development Flag
 ================
 

--- a/pure_interface.py
+++ b/pure_interface.py
@@ -7,9 +7,11 @@ from __future__ import division, print_function, absolute_import
 import abc
 import collections
 import dis
+import functools
 import inspect
 import types
 from typing import Any, Callable, List, Optional, Iterable, FrozenSet, Type, TypeVar, Tuple
+import typing
 import sys
 import warnings
 import weakref
@@ -817,3 +819,97 @@ def get_interface_properties_and_attribute_names(interface):
         return _get_pi_attribute(interface, 'interface_attribute_names')
     else:
         return frozenset()
+
+
+def _interface_from_anno(annotation):
+    """ Typically the annotation is the interface,  but if a default value of None is given the annotation is
+    a typing.Union[interface, None] a.k.a. Optional[interface]. Lets be nice and support those too.
+    """
+    try:
+        if issubclass(annotation, PureInterface):
+            return annotation
+    except TypeError:
+        pass
+    if hasattr(annotation, '__origin__') and hasattr(annotation, '__args__'):
+        # could be a typing.Union
+        if annotation.__origin__ is not typing.Union:
+            return None
+        for arg_type in annotation.__args__:
+            try:
+                if issubclass(arg_type, PureInterface):
+                    return arg_type
+            except TypeError:
+                pass
+
+    return None
+
+
+def adapt_args(*func_arg, **kwarg_types):
+    """ adapts arguments to the decorated function to the types given.  For example:
+
+            @adapt_args(foo=IFoo, bar=IBar)
+            def my_func(foo, bar):
+                pass
+
+        This would adapt the foo parameter to IFoo (with IFoo.optional_adapt(foo)) and bar to IBar (using IBar.adapt(bar))
+        before passing them to my_func.  `None` values are never adapted, so my_func(foo, None) will work, otherwise
+        ValueError is raised if the parameter is not adaptable.
+        All arguments must be specified as keyword arguments
+
+            @adapt_args(IFoo, IBar)   # NOT ALLOWED
+            def other_func(foo, bar):
+                pass
+
+        Parameters are only adapted if not None.  This is useful for optional args:
+
+            @adapt_args(foo=IFoo)
+            def optional_func(foo=None):
+                pass
+
+        In Python 3 the types can be taken from the annotations.  Optional[interface] is supported too.
+
+            @adapt_args
+            def my_func(foo: IFoo, bar: Optional[IBar] = None):
+                pass
+
+    """
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapped(*args, **kwargs):
+            adapted_kwargs = inspect.getcallargs(func, *args, **kwargs)
+            for name, interface in kwarg_types.items():
+                kwarg = adapted_kwargs.get(name, None)
+                adapted_kwargs[name] = PureInterfaceType.optional_adapt(interface, kwarg)
+
+            return func(**adapted_kwargs)
+        return wrapped
+
+    if func_arg:
+        if len(func_arg) != 1:
+            raise TypeError('Only one posititional argument permitted')
+        if not isinstance(func_arg[0], types.FunctionType):
+            raise TypeError('Positional argument must be a function (to decorate)')
+        if kwarg_types:
+            raise TypeError('keyword parameters not permitted with positional argument')
+        funcn = func_arg[0]
+        annotations = typing.get_type_hints(funcn)
+        if annotations is None:
+            annotations = {}
+        if not annotations:
+            warnings.warn('No annotations for {}. '
+                          'Add annotations or pass explicit argument types to adapt_args'.format(funcn.__name__),
+                          stacklevel=2)
+        for key, anno in annotations.items():
+            i_face = _interface_from_anno(anno)
+            if i_face is not None:
+                kwarg_types[key] = i_face
+        return decorator(funcn)
+
+    for key, i_face in kwarg_types.items():
+        try:
+            can_adapt = issubclass(i_face, PureInterface)
+        except TypeError:
+            can_adapt = False
+        if not can_adapt:
+            raise TypeError('adapt_args parameter values must be subtypes of PureInterface')
+    return decorator

--- a/tests/test_adapt_args2.py
+++ b/tests/test_adapt_args2.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import unittest
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+from pure_interface import adapt_args
+import pure_interface
+
+
+class I1(pure_interface.PureInterface):
+    foo = None
+
+    def bar(self):
+        pass
+
+
+class I2(pure_interface.PureInterface):
+    bar = None
+
+    def foo(self):
+        pass
+
+
+class Thing1(pure_interface.Concrete, I1):
+    def __init__(self):
+        self.foo = 'foo'
+
+    def bar(self):
+        print('bar:', self.foo)
+
+
+class Thing2(pure_interface.Concrete, I2):
+    def __init__(self):
+        self.bar = 'bar'
+
+    def foo(self):
+        print('foo:', self.bar)
+
+
+@adapt_args(y=I1)
+def some_func(x, y):
+    pass
+
+
+@adapt_args(b=I2)
+def other_func(a, b=None):
+    pass
+
+
+class TestAdaptArgsPy2(unittest.TestCase):
+    def test_adapt_args_works(self):
+        thing1 = Thing1()
+        adapt = mock.MagicMock()
+        with mock.patch('pure_interface.PureInterfaceType.optional_adapt', new=adapt):
+            some_func(3, thing1)
+
+        self.assertEqual(1, adapt.call_count)
+        adapt.assert_called_once_with(I1, thing1)
+
+    def test_adapt_optional_args_works_with_none(self):
+        thing1 = Thing1()
+        adapt = mock.MagicMock()
+        with mock.patch('pure_interface.PureInterfaceType.optional_adapt', new=adapt):
+            other_func(thing1)
+
+        adapt.assert_called_once_with(I2, None)
+
+    def test_adapt_optional_args_works(self):
+        thing1 = Thing1()
+        thing2 = Thing2()
+        adapt = mock.MagicMock()
+        with mock.patch('pure_interface.PureInterfaceType.optional_adapt', new=adapt):
+            other_func(thing1, thing2)
+
+        adapt.assert_called_once_with(I2, thing2)
+
+    def test_no_annotations_warning(self):
+        with mock.patch('warnings.warn') as warn:
+            @adapt_args
+            def no_anno(x, y):
+                pass
+
+            self.assertEqual(1, warn.call_count)
+
+    def test_type_error_raised_if_arg_not_subclass(self):
+        with self.assertRaises(TypeError):
+            @adapt_args(x=int)
+            def some_func(x):
+                pass
+
+    def test_type_error_raised_if_positional_arg_not_func(self):
+        with self.assertRaises(TypeError):
+            @adapt_args(I2)
+            def some_func(x):
+                pass
+
+    def test_type_error_raised_if_multiple_positional_args(self):
+        with self.assertRaises(TypeError):
+            @adapt_args(I1, I2)
+            def some_func(x):
+                pass
+
+    def test_type_error_raised_if_mixed_args(self):
+        with self.assertRaises(TypeError):
+            @adapt_args(I1, y=I2)
+            def some_func(x, y):
+                pass
+
+    def test_wrong_args_type_raises(self):
+        thing2 = Thing2()
+        with self.assertRaises(ValueError):
+            some_func(3, thing2)

--- a/tests/test_adaption.py
+++ b/tests/test_adaption.py
@@ -4,7 +4,10 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import pure_interface
 
 import unittest
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 
 class ISpeaker(pure_interface.PureInterface):
@@ -103,7 +106,7 @@ class SleepTalker(pure_interface.Concrete, ISleepTalker):
         self.is_asleep = sleeper.is_asleep
 
     def speak(self, volume):
-        super().speak(volume)
+        super(SleepTalker, self).speak(volume)
 
 
 class TestAdaption(unittest.TestCase):

--- a/tests/test_implementation_checks.py
+++ b/tests/test_implementation_checks.py
@@ -1,11 +1,15 @@
 import pure_interface
 
 import abc
-import mock
 import sys
 import unittest
 
 import six
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 
 class IAnimal(pure_interface.PureInterface):

--- a/tests/test_isinstance.py
+++ b/tests/test_isinstance.py
@@ -1,10 +1,14 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import mock
 import unittest
 
 import pure_interface
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 
 class IAnimal(pure_interface.PureInterface):

--- a/tests/test_py3/__init__.py
+++ b/tests/test_py3/__init__.py
@@ -1,0 +1,9 @@
+"""
+For tests that require python 3 only syntax.
+"""
+import six
+
+if six.PY2:
+    # don't import this package on python2
+    def load_tests(loader, standard_tests, pattern):
+        return standard_tests

--- a/tests/test_py3/test_adapt_args3.py
+++ b/tests/test_py3/test_adapt_args3.py
@@ -1,0 +1,184 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import unittest
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+from pure_interface import adapt_args
+import pure_interface
+from typing import Optional
+
+
+class I1(pure_interface.PureInterface):
+    foo = None
+
+    def bar(self):
+        pass
+
+
+class I2(pure_interface.PureInterface):
+    bar = None
+
+    def foo(self):
+        pass
+
+
+class Thing1(pure_interface.Concrete, I1):
+    def __init__(self):
+        self.foo = 'foo'
+
+    def bar(self):
+        print('bar:', self.foo)
+
+
+class Thing2(pure_interface.Concrete, I2):
+    def __init__(self):
+        self.bar = 'bar'
+
+    def foo(self):
+        print('foo:', self.bar)
+
+
+@adapt_args
+def some_func(x, y: I1):
+    return x is y
+
+@adapt_args
+def other_func(a: I1, b: I2 = None):
+    return a is b
+
+
+class I1(pure_interface.PureInterface):
+    foo = None
+
+    def bar(self):
+        pass
+
+
+class I2(pure_interface.PureInterface):
+    bar = None
+
+    def foo(self):
+        pass
+
+
+class Thing1(pure_interface.Concrete, I1):
+    def __init__(self):
+        self.foo = 'foo'
+
+    def bar(self):
+        print('bar:', self.foo)
+
+
+class Thing2(pure_interface.Concrete, I2):
+    def __init__(self):
+        self.bar = 'bar'
+
+    def foo(self):
+        print('foo:', self.bar)
+
+
+@adapt_args(y=I1)
+def some_func(x, y):
+    pass
+
+
+@adapt_args(b=I2)
+def other_func(a, b=None):
+    pass
+
+
+class TestAdaptArgsPy3(unittest.TestCase):
+    def test_adapt_args_works(self):
+        thing1 = Thing1()
+        adapt = mock.MagicMock()
+        with mock.patch('pure_interface.PureInterfaceType.optional_adapt', new=adapt):
+            some_func(3, thing1)
+
+        self.assertEqual(1, adapt.call_count)
+        adapt.assert_called_once_with(I1, thing1)
+
+    def test_adapt_optional_args_works_with_none(self):
+        thing1 = Thing1()
+        adapt = mock.MagicMock()
+        with mock.patch('pure_interface.PureInterfaceType.optional_adapt', new=adapt):
+            other_func(thing1)
+
+        adapt.assert_called_once_with(I2, None)
+
+    def test_adapt_optional_args_works(self):
+        thing1 = Thing1()
+        thing2 = Thing2()
+        adapt = mock.MagicMock()
+        with mock.patch('pure_interface.PureInterfaceType.optional_adapt', new=adapt):
+            other_func(thing1, thing2)
+
+        adapt.assert_called_once_with(I2, thing2)
+
+    def test_unsupported_annotations_are_skipped(self):
+        try:
+            @adapt_args
+            def some_func(x: int, y: I2):
+                pass
+        except Exception:
+            self.fail('Failed to ignore unsupported annotation')
+        adapt = mock.MagicMock()
+        thing2 = Thing2()
+        with mock.patch('pure_interface.PureInterfaceType.optional_adapt', new=adapt):
+            some_func(5, thing2)
+
+        adapt.assert_called_once_with(I2, thing2)
+
+    def test_unsupported_optional_annotations_are_skipped(self):
+        try:
+            @adapt_args
+            def some_func(x: Optional[int], y: I2):
+                pass
+        except Exception:
+            self.fail('Failed to ignore unsupported annotation')
+        adapt = mock.MagicMock()
+        thing2 = Thing2()
+        with mock.patch('pure_interface.PureInterfaceType.optional_adapt', new=adapt):
+            some_func(5, thing2)
+
+        adapt.assert_called_once_with(I2, thing2)
+
+    def test_no_annotations_warning(self):
+        with mock.patch('warnings.warn') as warn:
+            @adapt_args
+            def no_anno(x, y):
+                pass
+
+            self.assertEqual(1, warn.call_count)
+
+    def test_type_error_raised_if_arg_not_subclass(self):
+        with self.assertRaises(TypeError):
+            @adapt_args(x=int)
+            def some_func(x):
+                pass
+
+    def test_type_error_raised_if_positional_arg_not_func(self):
+        with self.assertRaises(TypeError):
+            @adapt_args(I2)
+            def some_func(x):
+                pass
+
+    def test_type_error_raised_if_multiple_positional_args(self):
+        with self.assertRaises(TypeError):
+            @adapt_args(I1, I2)
+            def some_func(x):
+                pass
+
+    def test_type_error_raised_if_mixed_args(self):
+        with self.assertRaises(TypeError):
+            @adapt_args(I1, y=I2)
+            def some_func(x, y):
+                pass
+
+    def test_wrong_args_type_raises(self):
+        thing2 = Thing2()
+        with self.assertRaises(ValueError):
+            some_func(3, thing2)


### PR DESCRIPTION
Changed test pattern to test*.
Use unittest.mock instead of mock when available.
Added python 3.7 to travis.
implements #35