### PR TITLE
LF-54899 Add pre-commit hooks for linting and Bentley copyrights

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,7 +13,7 @@ jobs:
   pre-commit:
     uses: seequent/leapfrog-actions-util/.github/workflows/run_pre_commit_checks.yml@run-pre-commit-checks-v1
     with:
-      python_version: 3.10
+      python_version: "3.10"
       requirements_file_path: requirements_dev.txt
       artifactory_user: ${{ vars.ARTIFACTORY_USER }}
     secrets:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,8 +13,8 @@ jobs:
   pre-commit:
     uses: seequent/leapfrog-actions-util/.github/workflows/run_pre_commit_checks.yml@run-pre-commit-checks-v1
     with:
-      python_version: 3.10.6
-      requirements_file_path: extras/python/requirements_dev.txt
+      python_version: 3.10
+      requirements_file_path: requirements_dev.txt
       artifactory_user: ${{ vars.ARTIFACTORY_USER }}
     secrets:
       artifactory_token: ${{ secrets.LEAPFROG_ARTIFACTORY_TOKEN }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,26 +1,21 @@
-name: pre-commit
+name: Run pre-commit checks
 
 on:
   push:
     branches:
       - master
-
   pull_request:
     branches:
       - master
+  workflow_dispatch:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
-
-      - name: Run pre-commit
-        uses: pre-commit/action@v3.0.1
+    uses: seequent/leapfrog-actions-util/.github/workflows/run_pre_commit_checks.yml@run-pre-commit-checks-v1
+    with:
+      python_version: 3.10.6
+      requirements_file_path: extras/python/requirements_dev.txt
+      artifactory_user: ${{ vars.ARTIFACTORY_USER }}
+    secrets:
+      artifactory_token: ${{ secrets.LEAPFROG_ARTIFACTORY_TOKEN }}
+      github_pat: ${{ secrets.SVC_LEAPFROG_AUTOMATION_GITHUB_PAT }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,25 @@
 repos:
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.4.0
-  hooks:
-    - id: check-toml
-    - id: trailing-whitespace
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: check-toml
+      - id: check-yaml
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
 
-- repo: https://github.com/psf/black
-  rev: 24.8.0
-  hooks:
-    - id: black
-      language_version: python3.10
+  - repo: https://github.com/seequent/bentley-copyright-utils
+    rev: v1.2.1
+    hooks:
+      - id: bentley-root-copyright-check
+      - id: bentley-file-copyright-check
 
-- repo: https://github.com/pycqa/isort
-  rev: 5.13.2
-  hooks:
-    - id: isort
+  - repo: https://github.com/psf/black
+    rev: 24.8.0
+    hooks:
+      - id: black
+        language_version: python3.10
+
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort

--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -1,0 +1,5 @@
+# COPYRIGHT
+
+All works in this repository are unpublished and proprietary property of Bentley Systems, Incorporated.
+
+Copyright (c) 2017-2024 Bentley Systems, Incorporated. All rights reserved.

--- a/pure_interface/__init__.py
+++ b/pure_interface/__init__.py
@@ -1,3 +1,8 @@
+# --------------------------------------------------------------------------------------------
+#  Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+#  See COPYRIGHT.md in the repository root for full copyright notice.
+# --------------------------------------------------------------------------------------------
+
 from ._sub_interface import sub_interface_of
 from .adaption import AdapterTracker, adapt_args, adapts, register_adapter
 from .delegation import Delegate

--- a/pure_interface/_sub_interface.py
+++ b/pure_interface/_sub_interface.py
@@ -1,3 +1,8 @@
+# --------------------------------------------------------------------------------------------
+#  Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+#  See COPYRIGHT.md in the repository root for full copyright notice.
+# --------------------------------------------------------------------------------------------
+
 """ decorator function for sub-interfaces
 
 A sub-interface is a non-empty subset of another, larger, interface.

--- a/pure_interface/adaption.py
+++ b/pure_interface/adaption.py
@@ -1,3 +1,8 @@
+# --------------------------------------------------------------------------------------------
+#  Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+#  See COPYRIGHT.md in the repository root for full copyright notice.
+# --------------------------------------------------------------------------------------------
+
 from __future__ import absolute_import, division, print_function
 
 import functools

--- a/pure_interface/delegation.py
+++ b/pure_interface/delegation.py
@@ -1,3 +1,8 @@
+# --------------------------------------------------------------------------------------------
+#  Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+#  See COPYRIGHT.md in the repository root for full copyright notice.
+# --------------------------------------------------------------------------------------------
+
 from __future__ import absolute_import, division, print_function
 
 import operator

--- a/pure_interface/errors.py
+++ b/pure_interface/errors.py
@@ -1,3 +1,9 @@
+# --------------------------------------------------------------------------------------------
+#  Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+#  See COPYRIGHT.md in the repository root for full copyright notice.
+# --------------------------------------------------------------------------------------------
+
+
 class PureInterfaceError(Exception):
     """All exceptions raised by this module are subclasses of this exception"""
 

--- a/pure_interface/interface.py
+++ b/pure_interface/interface.py
@@ -1,3 +1,8 @@
+# --------------------------------------------------------------------------------------------
+#  Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+#  See COPYRIGHT.md in the repository root for full copyright notice.
+# --------------------------------------------------------------------------------------------
+
 """
 pure_interface enforces empty functions and properties on interfaces and provides adaption and structural type checking.
 """

--- a/pure_interface/mypy_plugin.py
+++ b/pure_interface/mypy_plugin.py
@@ -1,3 +1,8 @@
+# --------------------------------------------------------------------------------------------
+#  Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+#  See COPYRIGHT.md in the repository root for full copyright notice.
+# --------------------------------------------------------------------------------------------
+
 from collections.abc import Callable
 from typing import Dict, Final, List, Optional, TypeAlias, cast
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,2 +1,3 @@
 -r requirements.txt
 mypy
+pre-commit==3.8.0

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,8 @@
+# --------------------------------------------------------------------------------------------
+#  Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+#  See COPYRIGHT.md in the repository root for full copyright notice.
+# --------------------------------------------------------------------------------------------
+
 import warnings
 
 warnings.filterwarnings("ignore", category=UserWarning)

--- a/tests/interface_module.py
+++ b/tests/interface_module.py
@@ -1,3 +1,8 @@
+# --------------------------------------------------------------------------------------------
+#  Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+#  See COPYRIGHT.md in the repository root for full copyright notice.
+# --------------------------------------------------------------------------------------------
+
 import pure_interface
 
 

--- a/tests/mypy_source.py
+++ b/tests/mypy_source.py
@@ -1,3 +1,8 @@
+# --------------------------------------------------------------------------------------------
+#  Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+#  See COPYRIGHT.md in the repository root for full copyright notice.
+# --------------------------------------------------------------------------------------------
+
 """With the pure-interface mypy plugin enabled, mypy should validate this file without error.
 
 This is working except for dataclasses __init__ call arguments.

--- a/tests/temp.py
+++ b/tests/temp.py
@@ -1,3 +1,8 @@
+# --------------------------------------------------------------------------------------------
+#  Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+#  See COPYRIGHT.md in the repository root for full copyright notice.
+# --------------------------------------------------------------------------------------------
+
 import dataclasses
 
 import pure_interface

--- a/tests/test_adapt_args_anno.py
+++ b/tests/test_adapt_args_anno.py
@@ -1,3 +1,8 @@
+# --------------------------------------------------------------------------------------------
+#  Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+#  See COPYRIGHT.md in the repository root for full copyright notice.
+# --------------------------------------------------------------------------------------------
+
 import unittest
 
 try:

--- a/tests/test_adapt_args_no_anno.py
+++ b/tests/test_adapt_args_no_anno.py
@@ -1,3 +1,8 @@
+# --------------------------------------------------------------------------------------------
+#  Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+#  See COPYRIGHT.md in the repository root for full copyright notice.
+# --------------------------------------------------------------------------------------------
+
 import unittest
 
 import pure_interface.errors

--- a/tests/test_adaption.py
+++ b/tests/test_adaption.py
@@ -1,3 +1,8 @@
+# --------------------------------------------------------------------------------------------
+#  Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+#  See COPYRIGHT.md in the repository root for full copyright notice.
+# --------------------------------------------------------------------------------------------
+
 import unittest
 import warnings
 from unittest import mock

--- a/tests/test_dataclass_support.py
+++ b/tests/test_dataclass_support.py
@@ -1,3 +1,8 @@
+# --------------------------------------------------------------------------------------------
+#  Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+#  See COPYRIGHT.md in the repository root for full copyright notice.
+# --------------------------------------------------------------------------------------------
+
 import unittest
 from dataclasses import dataclass
 

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -1,3 +1,8 @@
+# --------------------------------------------------------------------------------------------
+#  Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+#  See COPYRIGHT.md in the repository root for full copyright notice.
+# --------------------------------------------------------------------------------------------
+
 import dataclasses
 import unittest
 from unittest import mock

--- a/tests/test_func_sigs3.py
+++ b/tests/test_func_sigs3.py
@@ -1,3 +1,8 @@
+# --------------------------------------------------------------------------------------------
+#  Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+#  See COPYRIGHT.md in the repository root for full copyright notice.
+# --------------------------------------------------------------------------------------------
+
 import types
 import unittest
 

--- a/tests/test_func_sigs_po.py
+++ b/tests/test_func_sigs_po.py
@@ -1,3 +1,8 @@
+# --------------------------------------------------------------------------------------------
+#  Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+#  See COPYRIGHT.md in the repository root for full copyright notice.
+# --------------------------------------------------------------------------------------------
+
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
 

--- a/tests/test_function_sigs.py
+++ b/tests/test_function_sigs.py
@@ -1,3 +1,8 @@
+# --------------------------------------------------------------------------------------------
+#  Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+#  See COPYRIGHT.md in the repository root for full copyright notice.
+# --------------------------------------------------------------------------------------------
+
 import types
 import unittest
 

--- a/tests/test_generic_support.py
+++ b/tests/test_generic_support.py
@@ -1,3 +1,8 @@
+# --------------------------------------------------------------------------------------------
+#  Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+#  See COPYRIGHT.md in the repository root for full copyright notice.
+# --------------------------------------------------------------------------------------------
+
 import unittest
 from typing import Iterable, List, TypeVar
 

--- a/tests/test_implementation_checks.py
+++ b/tests/test_implementation_checks.py
@@ -1,3 +1,8 @@
+# --------------------------------------------------------------------------------------------
+#  Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+#  See COPYRIGHT.md in the repository root for full copyright notice.
+# --------------------------------------------------------------------------------------------
+
 import abc
 import unittest
 import warnings

--- a/tests/test_inheritance.py
+++ b/tests/test_inheritance.py
@@ -1,3 +1,8 @@
+# --------------------------------------------------------------------------------------------
+#  Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+#  See COPYRIGHT.md in the repository root for full copyright notice.
+# --------------------------------------------------------------------------------------------
+
 import unittest
 
 import pure_interface

--- a/tests/test_isinstance.py
+++ b/tests/test_isinstance.py
@@ -1,3 +1,8 @@
+# --------------------------------------------------------------------------------------------
+#  Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+#  See COPYRIGHT.md in the repository root for full copyright notice.
+# --------------------------------------------------------------------------------------------
+
 import io
 import unittest
 import warnings

--- a/tests/test_meta_classes.py
+++ b/tests/test_meta_classes.py
@@ -1,3 +1,8 @@
+# --------------------------------------------------------------------------------------------
+#  Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+#  See COPYRIGHT.md in the repository root for full copyright notice.
+# --------------------------------------------------------------------------------------------
+
 import abc
 import unittest
 

--- a/tests/test_module_funcs.py
+++ b/tests/test_module_funcs.py
@@ -1,3 +1,8 @@
+# --------------------------------------------------------------------------------------------
+#  Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+#  See COPYRIGHT.md in the repository root for full copyright notice.
+# --------------------------------------------------------------------------------------------
+
 import unittest
 
 from pure_interface import *

--- a/tests/test_no_content_checks.py
+++ b/tests/test_no_content_checks.py
@@ -1,3 +1,8 @@
+# --------------------------------------------------------------------------------------------
+#  Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+#  See COPYRIGHT.md in the repository root for full copyright notice.
+# --------------------------------------------------------------------------------------------
+
 import abc
 import unittest
 

--- a/tests/test_singledispatch.py
+++ b/tests/test_singledispatch.py
@@ -1,3 +1,8 @@
+# --------------------------------------------------------------------------------------------
+#  Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+#  See COPYRIGHT.md in the repository root for full copyright notice.
+# --------------------------------------------------------------------------------------------
+
 import unittest
 from functools import singledispatchmethod
 from typing import Any

--- a/tests/test_sub_interfaces.py
+++ b/tests/test_sub_interfaces.py
@@ -1,3 +1,8 @@
+# --------------------------------------------------------------------------------------------
+#  Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+#  See COPYRIGHT.md in the repository root for full copyright notice.
+# --------------------------------------------------------------------------------------------
+
 import dataclasses
 import unittest
 

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -1,3 +1,8 @@
+# --------------------------------------------------------------------------------------------
+#  Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+#  See COPYRIGHT.md in the repository root for full copyright notice.
+# --------------------------------------------------------------------------------------------
+
 import unittest
 
 from pure_interface import *


### PR DESCRIPTION
Adds pre-commit infrastructure to enforce Bentley copyrights are kept up-to-date, and file content is linted.