### PR TITLE
Add special attributes introduced in Python 3.13

### DIFF
--- a/pure_interface/interface.py
+++ b/pure_interface/interface.py
@@ -137,6 +137,8 @@ def _builtin_attrs(name: str) -> bool:
         "_abc_negative_cache",
         "_pi",
         "_pi_unwrap_decorators",
+        "__firstlineno__",
+        "__static_attributes__",
     )
 
 


### PR DESCRIPTION
Add special attributes introduced in Python 3.13

see https://docs.python.org/3/reference/datamodel.html#special-attributes