### PR TITLE
Cache adapters in adapt call

### DIFF
--- a/pure_interface/__init__.py
+++ b/pure_interface/__init__.py
@@ -19,4 +19,4 @@ from .interface import (
     type_is_interface,
 )
 
-__version__ = "8.4.0"  # Don't change this manually - run `bump-my-version bump [major|minor|patch]` instead
+__version__ = "8.5.0"  # Don't change this manually - run `bump-my-version bump [major|minor|patch]` instead

--- a/pure_interface/adaption.py
+++ b/pure_interface/adaption.py
@@ -82,7 +82,11 @@ def register_adapter(
         raise AdaptionError("{} already has an adapter to {}".format(from_type, to_interface))
 
     adapters[from_type] = adapter
-    clear_adapter_caches(to_interface, from_type)
+    # Clears all cached adapter lookups for to_interface and its ancestors.
+    # This is safe because registration is expected to happen at startup.
+    # Calling register_adapter at runtime will cause all cached adapters for
+    # the interface to be re-resolved on next use.
+    clear_adapter_caches(to_interface)
 
 
 class AdapterTracker(object):

--- a/pure_interface/adaption.py
+++ b/pure_interface/adaption.py
@@ -16,6 +16,7 @@ from .interface import (
     AnInterface,
     Interface,
     InterfaceType,
+    clear_adapter_caches,
     get_pi_attribute,
     get_type_interfaces,
     type_is_interface,
@@ -81,6 +82,7 @@ def register_adapter(
         raise AdaptionError("{} already has an adapter to {}".format(from_type, to_interface))
 
     adapters[from_type] = adapter
+    clear_adapter_caches(to_interface, from_type)
 
 
 class AdapterTracker(object):

--- a/pure_interface/interface.py
+++ b/pure_interface/interface.py
@@ -32,6 +32,7 @@ from typing import (
     Tuple,
     Type,
     TypeVar,
+    cast,
 )
 
 from .errors import AdaptionError, InterfaceError
@@ -589,7 +590,7 @@ def _get_adapter(cls: AnInterfaceType, obj_type: Type) -> Optional[Callable]:
     candidate_interfaces.reverse()  # prefer this class over sub-class adapters
     for subcls in candidate_interfaces:
         if type_is_interface(subcls):
-            adapters.update(subcls._pi.adapters)
+            adapters.update(cast(AnInterfaceType, subcls)._pi.adapters)
     if not adapters:
         return None
 

--- a/pure_interface/interface.py
+++ b/pure_interface/interface.py
@@ -102,12 +102,12 @@ class _PIAttributes:
         # keep an ordered list for dataclass
         self.interface_attribute_names: List[str] = _unique_list(interface_attribute_names)
         self.interface_method_signatures = interface_method_signatures
-        self.adapters = weakref.WeakKeyDictionary()  # type: ignore
-        self.registered_types = weakref.WeakSet()  # type: ignore
-        self.registered_by: weakref.WeakSet = weakref.WeakSet()  # interfaces that have registered this one
+        self.adapters: weakref.WeakKeyDictionary[type, Callable] = weakref.WeakKeyDictionary()
+        self.registered_types: weakref.WeakSet[type] = weakref.WeakSet()
+        self.registered_by: weakref.WeakSet[type] = weakref.WeakSet()  # interfaces that have registered this one
         self.structural_subclasses: Set[type] = set()
         self.impl_wrapper_type: Optional[type] = None
-        self.adapter_cache = weakref.WeakKeyDictionary()  # type: ignore
+        self.adapter_cache: weakref.WeakKeyDictionary[type, Optional[Callable]] = weakref.WeakKeyDictionary()
 
     @property
     def interface_names(self) -> FrozenSet[str]:

--- a/pure_interface/interface.py
+++ b/pure_interface/interface.py
@@ -63,18 +63,12 @@ AnInterface = TypeVar("AnInterface", bound="Interface")
 AnInterfaceType = TypeVar("AnInterfaceType", bound="InterfaceType")
 
 
-def clear_adapter_caches(interface_cls: type, from_type: Optional[type] = None) -> None:
-    """Clear adapter caches for the given interface and all its ancestor interfaces.
-    If from_type is given, only the cache entry for that specific type is removed;
-    otherwise all entries are cleared.
-    """
+def clear_adapter_caches(interface_cls: type) -> None:
+    """Clear adapter caches for the given interface and all its ancestor interfaces."""
     for cls in interface_cls.__mro__:
         cache = get_pi_attribute(cls, "_adapter_cache")
         if cache is not None:
-            if from_type is None:
-                cache.clear()
-            else:
-                cache.pop(from_type, None)
+            cache.clear()
 
 
 def _unique_list(items: Iterable[Any]) -> List[Any]:

--- a/pure_interface/interface.py
+++ b/pure_interface/interface.py
@@ -103,7 +103,7 @@ class _PIAttributes:
         self.registered_types = weakref.WeakSet()  # type: ignore
         self.structural_subclasses: Set[type] = set()
         self.impl_wrapper_type: Optional[type] = None
-        self.adapter_cache: weakref.WeakKeyDictionary[type, Optional[Callable]] = weakref.WeakKeyDictionary()
+        self.adapter_cache = weakref.WeakKeyDictionary()  # type: ignore
 
     @property
     def interface_names(self) -> FrozenSet[str]:

--- a/pure_interface/interface.py
+++ b/pure_interface/interface.py
@@ -66,7 +66,7 @@ AnInterfaceType = TypeVar("AnInterfaceType", bound="InterfaceType")
 def clear_adapter_caches(interface_cls: type) -> None:
     """Clear adapter caches for the given interface and all its ancestor interfaces."""
     for cls in interface_cls.__mro__:
-        cache = get_pi_attribute(cls, "_adapter_cache")
+        cache = get_pi_attribute(cls, "adapter_cache")
         if cache is not None:
             cache.clear()
 
@@ -103,7 +103,7 @@ class _PIAttributes:
         self.registered_types = weakref.WeakSet()  # type: ignore
         self.structural_subclasses: Set[type] = set()
         self.impl_wrapper_type: Optional[type] = None
-        self._adapter_cache: Dict[type, Optional[Callable]] = {}
+        self.adapter_cache: weakref.WeakKeyDictionary[type, Optional[Callable]] = weakref.WeakKeyDictionary()
 
     @property
     def interface_names(self) -> FrozenSet[str]:
@@ -765,7 +765,7 @@ class InterfaceType(abc.ABCMeta):
             adapter = no_adaption
         else:
             obj_type = type(obj)
-            cache = get_pi_attribute(cls, "_adapter_cache")
+            cache = get_pi_attribute(cls, "adapter_cache")
             if obj_type not in cache:
                 cache[obj_type] = _get_adapter(cls, obj_type)
             adapter = cache[obj_type]

--- a/pure_interface/interface.py
+++ b/pure_interface/interface.py
@@ -63,6 +63,19 @@ AnInterface = TypeVar("AnInterface", bound="Interface")
 AnInterfaceType = TypeVar("AnInterfaceType", bound="InterfaceType")
 
 
+def clear_adapter_caches(interface_cls: type, from_type: Optional[type] = None) -> None:
+    """Clear adapter caches for the given interface and all its ancestor interfaces.
+    If from_type is given, only the cache entry for that specific type is removed;
+    otherwise all entries are cleared.
+    """
+    for cls in interface_cls.__mro__:
+        cache = get_pi_attribute(cls, "_adapter_cache")
+        if cache is not None:
+            if from_type is None:
+                cache.clear()
+            else:
+                cache.pop(from_type, None)
+
 def _unique_list(items: Iterable[Any]) -> List[Any]:
     seen = set()
     unique_items = []
@@ -95,6 +108,7 @@ class _PIAttributes:
         self.registered_types = weakref.WeakSet()  # type: ignore
         self.structural_subclasses: Set[type] = set()
         self.impl_wrapper_type: Optional[type] = None
+        self._adapter_cache: Dict[type, Optional[Callable]] = {}
 
     @property
     def interface_names(self) -> FrozenSet[str]:
@@ -755,7 +769,11 @@ class InterfaceType(abc.ABCMeta):
         if InterfaceType._provided_by(cls, obj, allow_implicit=allow_implicit):
             adapter = no_adaption
         else:
-            adapter = _get_adapter(cls, type(obj))
+            obj_type = type(obj)
+            cache = get_pi_attribute(cls, "_adapter_cache")
+            if obj_type not in cache:
+                cache[obj_type] = _get_adapter(cls, obj_type)
+            adapter = cache[obj_type]
             if adapter is None:
                 raise AdaptionError("Cannot adapt {} to {}".format(obj, cls.__name__))
 
@@ -795,6 +813,7 @@ class InterfaceType(abc.ABCMeta):
     def register(cls, subclass: Type[_T]) -> Type[_T]:
         if type_is_interface(cls):
             cls._pi.registered_types.add(subclass)  # type: ignore[attr-defined]
+            clear_adapter_caches(cls)
         return super().register(subclass)
 
 

--- a/pure_interface/interface.py
+++ b/pure_interface/interface.py
@@ -64,11 +64,14 @@ AnInterfaceType = TypeVar("AnInterfaceType", bound="InterfaceType")
 
 
 def clear_adapter_caches(interface_cls: type) -> None:
-    """Clear adapter caches for the given interface and all its ancestor interfaces."""
-    for cls in interface_cls.__mro__:
-        cache = get_pi_attribute(cls, "adapter_cache")
-        if cache is not None:
-            cache.clear()
+    """Clear adapter caches for the given interface, all its ancestor interfaces,
+    and any interfaces that have registered this interface via .register()."""
+    affected = [interface_cls] + list(get_pi_attribute(interface_cls, "registered_by", ()))
+    for affected_cls in affected:
+        for cls in affected_cls.__mro__:
+            cache = get_pi_attribute(cls, "adapter_cache")
+            if cache is not None:
+                cache.clear()
 
 
 def _unique_list(items: Iterable[Any]) -> List[Any]:
@@ -101,6 +104,7 @@ class _PIAttributes:
         self.interface_method_signatures = interface_method_signatures
         self.adapters = weakref.WeakKeyDictionary()  # type: ignore
         self.registered_types = weakref.WeakSet()  # type: ignore
+        self.registered_by: weakref.WeakSet = weakref.WeakSet()  # interfaces that have registered this one
         self.structural_subclasses: Set[type] = set()
         self.impl_wrapper_type: Optional[type] = None
         self.adapter_cache: weakref.WeakKeyDictionary[type, Optional[Callable]] = weakref.WeakKeyDictionary()
@@ -765,10 +769,12 @@ class InterfaceType(abc.ABCMeta):
             adapter = no_adaption
         else:
             obj_type = type(obj)
-            cache = get_pi_attribute(cls, "adapter_cache")
-            if obj_type not in cache:
+            cache = cls._pi.adapter_cache
+            try:
+                adapter = cache[obj_type]
+            except KeyError:
                 cache[obj_type] = _get_adapter(cls, obj_type)
-            adapter = cache[obj_type]
+                adapter = cache[obj_type]
             if adapter is None:
                 raise AdaptionError("Cannot adapt {} to {}".format(obj, cls.__name__))
 
@@ -808,6 +814,8 @@ class InterfaceType(abc.ABCMeta):
     def register(cls, subclass: Type[_T]) -> Type[_T]:
         if type_is_interface(cls):
             cls._pi.registered_types.add(subclass)  # type: ignore[attr-defined]
+            if type_is_interface(subclass):
+                subclass._pi.registered_by.add(cls)  # type: ignore[attr-defined]
             clear_adapter_caches(cls)
         return super().register(subclass)
 

--- a/pure_interface/interface.py
+++ b/pure_interface/interface.py
@@ -76,6 +76,7 @@ def clear_adapter_caches(interface_cls: type, from_type: Optional[type] = None) 
             else:
                 cache.pop(from_type, None)
 
+
 def _unique_list(items: Iterable[Any]) -> List[Any]:
     seen = set()
     unique_items = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pure-interface"
-version = "8.4.0"
+version = "8.5.0"
 description = "A Python interface library that disallows function body content on interfaces and supports adaption."
 keywords = ["interface", "protocol", "adaption", "structural", "dataclass"]
 authors = [
@@ -43,7 +43,7 @@ line-length = 120
 profile = "black"
 
 [tool.bumpversion]
-current_version = "8.4.0"
+current_version = "8.5.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 search = "{current_version}"

--- a/tests/test_adapter_cache.py
+++ b/tests/test_adapter_cache.py
@@ -20,6 +20,13 @@ class IDog(IAnimal, Interface):
         pass
 
 
+class ICreature(Interface):
+    """Separate interface used to test cache invalidation via .register()."""
+
+    def speak(self):
+        pass
+
+
 class Cat:
     pass
 
@@ -48,23 +55,54 @@ class HawkToIDog(IDog):
 
 
 class Fish:
-    pass  # never adapted — used to test None caching
+    pass  # used to test None caching and late adapter registration
+
+
+class FishToIAnimal(IAnimal):
+    def __init__(self, obj):
+        pass
+
+    def speak(self):
+        return "blub"
+
+
+class FishToIDog(IDog):
+    def __init__(self, obj):
+        pass
+
+    def speak(self):
+        return "blub"
+
+    def fetch(self):
+        return "swim"
 
 
 class Iguana:
     pass  # used for register() test
 
 
+ICreature.register(IAnimal)
+
+
+def _register_adapters():
+    register_adapter(CatToIAnimal, Cat, IAnimal)
+    register_adapter(HawkToIDog, Hawk, IDog)
+
+
 class TestAdapterCache(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         pure_interface.set_is_development(True)
-        register_adapter(CatToIAnimal, Cat, IAnimal)
-        register_adapter(HawkToIDog, Hawk, IDog)
 
     def setUp(self):
+        _register_adapters()
+
+    def tearDown(self):
         IAnimal._pi.adapter_cache.clear()
         IDog._pi.adapter_cache.clear()
+        ICreature._pi.adapter_cache.clear()
+        IAnimal._pi.adapters.clear()
+        IDog._pi.adapters.clear()
 
     def test_adapter_cached_after_adapt(self):
         IAnimal.adapt(Cat(), interface_only=False)
@@ -124,39 +162,38 @@ class TestAdapterCache(unittest.TestCase):
         self.assertEqual(len(IAnimal._pi.adapter_cache), 0)
 
     def test_stale_none_on_parent_cleared_when_adapter_registered_on_child(self):
-        # Fresh types so no adapters are pre-registered
-        class IVehicle(Interface):
-            def drive(self):
-                pass
-
-        class ICar(IVehicle, Interface):
-            def park(self):
-                pass
-
-        class Bicycle:
-            pass
-
-        class BicycleToICar(ICar):
-            def __init__(self, obj):
-                pass
-
-            def drive(self):
-                pass
-
-            def park(self):
-                pass
-
-        # Prime a stale None on both parent and child: no adapter for Bicycle yet
-        self.assertIsNone(IVehicle.adapt_or_none(Bicycle(), interface_only=False))
-        self.assertIsNone(ICar.adapt_or_none(Bicycle(), interface_only=False))
-        self.assertIsNone(IVehicle._pi.adapter_cache[Bicycle])
-        self.assertIsNone(ICar._pi.adapter_cache[Bicycle])
+        # Prime a stale None on both parent and child: no adapter for Fish yet
+        self.assertIsNone(IAnimal.adapt_or_none(Fish(), interface_only=False))
+        self.assertIsNone(IDog.adapt_or_none(Fish(), interface_only=False))
+        self.assertIsNone(IAnimal._pi.adapter_cache[Fish])
+        self.assertIsNone(IDog._pi.adapter_cache[Fish])
 
         # Registering on the child must evict the stale entry from both caches
-        register_adapter(BicycleToICar, Bicycle, ICar)
-        self.assertNotIn(Bicycle, IVehicle._pi.adapter_cache)
-        self.assertNotIn(Bicycle, ICar._pi.adapter_cache)
+        register_adapter(FishToIDog, Fish, IDog)
+        self.assertNotIn(Fish, IAnimal._pi.adapter_cache)
+        self.assertNotIn(Fish, IDog._pi.adapter_cache)
 
-        # Parent can now adapt Bicycle via the child's adapter
-        adapted = IVehicle.adapt(Bicycle(), interface_only=False)
-        self.assertIsInstance(adapted, BicycleToICar)
+        # Parent can now adapt Fish via the child's adapter
+        adapted = IAnimal.adapt(Fish(), interface_only=False)
+        self.assertIsInstance(adapted, FishToIDog)
+
+    def test_stale_none_cleared_when_adapter_added_to_registered_interface(self):
+        # IAnimal is registered as a virtual subclass of ICreature at module level.
+        # _get_adapter(ICreature, T) therefore reads IAnimal._pi.adapters.
+        # If a stale None is cached on ICreature and a new adapter is later added
+        # to IAnimal, the stale entry must be evicted so ICreature can find the adapter.
+
+        # Prime ICreature's cache with None — no adapter for Fish exists yet
+        self.assertIsNone(ICreature.adapt_or_none(Fish(), interface_only=False))
+        self.assertIn(Fish, ICreature._pi.adapter_cache)
+        self.assertIsNone(ICreature._pi.adapter_cache[Fish])
+
+        # Register an adapter for Fish on IAnimal
+        register_adapter(FishToIAnimal, Fish, IAnimal)
+
+        # ICreature's stale None should have been evicted
+        self.assertNotIn(Fish, ICreature._pi.adapter_cache)
+
+        # ICreature should now successfully adapt Fish via IAnimal's adapter
+        adapted = ICreature.adapt(Fish(), interface_only=False)
+        self.assertIsInstance(adapted, FishToIAnimal)

--- a/tests/test_adapter_cache.py
+++ b/tests/test_adapter_cache.py
@@ -1,0 +1,159 @@
+# --------------------------------------------------------------------------------------------
+#  Copyright (c) 2024 Bentley Systems, Incorporated. All rights reserved.
+# --------------------------------------------------------------------------------------------
+
+import unittest
+from unittest import mock
+
+import pure_interface
+from pure_interface import Interface, interface
+from pure_interface.adaption import register_adapter
+
+
+class IAnimal(Interface):
+    def speak(self):
+        pass
+
+
+class IDog(IAnimal, Interface):
+    def fetch(self):
+        pass
+
+
+class Cat:
+    pass
+
+
+class CatToIAnimal(IAnimal):
+    def __init__(self, obj):
+        pass
+
+    def speak(self):
+        return "meow"
+
+
+class Hawk:
+    pass
+
+
+class HawkToIDog(IDog):
+    def __init__(self, obj):
+        pass
+
+    def speak(self):
+        return "screech"
+
+    def fetch(self):
+        return "prey"
+
+
+class Fish:
+    pass  # never adapted — used to test None caching
+
+
+class Iguana:
+    pass  # used for register() test
+
+
+class TestAdapterCache(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        pure_interface.set_is_development(True)
+        register_adapter(CatToIAnimal, Cat, IAnimal)
+        register_adapter(HawkToIDog, Hawk, IDog)
+
+    def setUp(self):
+        IAnimal._pi._adapter_cache.clear()
+        IDog._pi._adapter_cache.clear()
+
+    def test_adapter_cached_after_adapt(self):
+        IAnimal.adapt(Cat(), interface_only=False)
+        self.assertIn(Cat, IAnimal._pi._adapter_cache)
+        self.assertIs(IAnimal._pi._adapter_cache[Cat], CatToIAnimal)
+
+    def test_get_adapter_called_only_once_for_repeated_adapts(self):
+        cat = Cat()
+        with mock.patch("pure_interface.interface._get_adapter", wraps=interface._get_adapter) as mock_get:
+            IAnimal.adapt(cat, interface_only=False)
+            IAnimal.adapt(cat, interface_only=False)
+        mock_get.assert_called_once()
+
+    def test_none_cached_when_no_adapter_exists(self):
+        IAnimal.adapt_or_none(Fish(), interface_only=False)
+        self.assertIn(Fish, IAnimal._pi._adapter_cache)
+        self.assertIsNone(IAnimal._pi._adapter_cache[Fish])
+
+    def test_get_adapter_called_only_once_for_repeated_none_results(self):
+        fish = Fish()
+        with mock.patch("pure_interface.interface._get_adapter", wraps=interface._get_adapter) as mock_get:
+            IAnimal.adapt_or_none(fish, interface_only=False)
+            IAnimal.adapt_or_none(fish, interface_only=False)
+        mock_get.assert_called_once()
+
+    def test_clear_adapter_caches_clears_interface_cache(self):
+        IAnimal._pi._adapter_cache[Cat] = CatToIAnimal
+        interface.clear_adapter_caches(IAnimal)
+        self.assertEqual(IAnimal._pi._adapter_cache, {})
+
+    def test_clear_adapter_caches_on_child_clears_parent_cache(self):
+        # IAnimal's cache should be cleared when IDog's adapters change,
+        # because _get_adapter(IAnimal, ...) collects adapters from IAnimal.__subclasses__()
+        IAnimal._pi._adapter_cache[Hawk] = None
+        interface.clear_adapter_caches(IDog)
+        self.assertNotIn(Hawk, IAnimal._pi._adapter_cache)
+
+    def test_parent_interface_finds_adapter_registered_on_child(self):
+        adapted = IAnimal.adapt(Hawk(), interface_only=False)
+        self.assertIsInstance(adapted, HawkToIDog)
+
+    def test_parent_caches_adapter_found_via_child(self):
+        IAnimal.adapt(Hawk(), interface_only=False)
+        self.assertIn(Hawk, IAnimal._pi._adapter_cache)
+        self.assertIs(IAnimal._pi._adapter_cache[Hawk], HawkToIDog)
+
+    def test_register_type_clears_cache(self):
+        IAnimal._pi._adapter_cache[Iguana] = None
+        IAnimal.register(Iguana)
+        self.assertNotIn(Iguana, IAnimal._pi._adapter_cache)
+
+    def test_register_adapter_only_evicts_from_type_entry(self):
+        # Pre-populate cache with an unrelated entry
+        IAnimal._pi._adapter_cache[Fish] = None
+        # Register a new adapter for Iguana
+        register_adapter(lambda obj: CatToIAnimal(obj), Iguana, IAnimal)
+        # The Iguana entry should be gone (evicted)
+        self.assertNotIn(Iguana, IAnimal._pi._adapter_cache)
+        # The Fish entry should be untouched
+        self.assertIn(Fish, IAnimal._pi._adapter_cache)
+        self.assertIsNone(IAnimal._pi._adapter_cache[Fish])
+
+    def test_stale_none_on_parent_cleared_when_adapter_registered_on_child(self):
+        # Fresh types so no adapters are pre-registered
+        class IVehicle(Interface):
+            def drive(self): pass
+
+        class ICar(IVehicle, Interface):
+            def park(self): pass
+
+        class Bicycle:
+            pass
+
+        class BicycleToICar(ICar):
+            def __init__(self, obj): pass
+            def drive(self): pass
+            def park(self): pass
+
+        # Prime a stale None on both parent and child: no adapter for Bicycle yet
+        self.assertIsNone(IVehicle.adapt_or_none(Bicycle(), interface_only=False))
+        self.assertIsNone(ICar.adapt_or_none(Bicycle(), interface_only=False))
+        self.assertIsNone(IVehicle._pi._adapter_cache[Bicycle])
+        self.assertIsNone(ICar._pi._adapter_cache[Bicycle])
+
+        # Registering on the child must evict the stale entry from both caches
+        register_adapter(BicycleToICar, Bicycle, ICar)
+        self.assertNotIn(Bicycle, IVehicle._pi._adapter_cache)
+        self.assertNotIn(Bicycle, ICar._pi._adapter_cache)
+
+        # Parent can now adapt Bicycle via the child's adapter
+        adapted = IVehicle.adapt(Bicycle(), interface_only=False)
+        self.assertIsInstance(adapted, BicycleToICar)

--- a/tests/test_adapter_cache.py
+++ b/tests/test_adapter_cache.py
@@ -116,16 +116,12 @@ class TestAdapterCache(unittest.TestCase):
         IAnimal.register(Iguana)
         self.assertNotIn(Iguana, IAnimal._pi._adapter_cache)
 
-    def test_register_adapter_only_evicts_from_type_entry(self):
+    def test_register_adapter_clears_entire_cache(self):
         # Pre-populate cache with an unrelated entry
         IAnimal._pi._adapter_cache[Fish] = None
-        # Register a new adapter for Iguana
+        # Registering any adapter should wipe the whole cache
         register_adapter(lambda obj: CatToIAnimal(obj), Iguana, IAnimal)
-        # The Iguana entry should be gone (evicted)
-        self.assertNotIn(Iguana, IAnimal._pi._adapter_cache)
-        # The Fish entry should be untouched
-        self.assertIn(Fish, IAnimal._pi._adapter_cache)
-        self.assertIsNone(IAnimal._pi._adapter_cache[Fish])
+        self.assertEqual(IAnimal._pi._adapter_cache, {})
 
     def test_stale_none_on_parent_cleared_when_adapter_registered_on_child(self):
         # Fresh types so no adapters are pre-registered

--- a/tests/test_adapter_cache.py
+++ b/tests/test_adapter_cache.py
@@ -130,18 +130,25 @@ class TestAdapterCache(unittest.TestCase):
     def test_stale_none_on_parent_cleared_when_adapter_registered_on_child(self):
         # Fresh types so no adapters are pre-registered
         class IVehicle(Interface):
-            def drive(self): pass
+            def drive(self):
+                pass
 
         class ICar(IVehicle, Interface):
-            def park(self): pass
+            def park(self):
+                pass
 
         class Bicycle:
             pass
 
         class BicycleToICar(ICar):
-            def __init__(self, obj): pass
-            def drive(self): pass
-            def park(self): pass
+            def __init__(self, obj):
+                pass
+
+            def drive(self):
+                pass
+
+            def park(self):
+                pass
 
         # Prime a stale None on both parent and child: no adapter for Bicycle yet
         self.assertIsNone(IVehicle.adapt_or_none(Bicycle(), interface_only=False))

--- a/tests/test_adapter_cache.py
+++ b/tests/test_adapter_cache.py
@@ -63,13 +63,13 @@ class TestAdapterCache(unittest.TestCase):
         register_adapter(HawkToIDog, Hawk, IDog)
 
     def setUp(self):
-        IAnimal._pi._adapter_cache.clear()
-        IDog._pi._adapter_cache.clear()
+        IAnimal._pi.adapter_cache.clear()
+        IDog._pi.adapter_cache.clear()
 
     def test_adapter_cached_after_adapt(self):
         IAnimal.adapt(Cat(), interface_only=False)
-        self.assertIn(Cat, IAnimal._pi._adapter_cache)
-        self.assertIs(IAnimal._pi._adapter_cache[Cat], CatToIAnimal)
+        self.assertIn(Cat, IAnimal._pi.adapter_cache)
+        self.assertIs(IAnimal._pi.adapter_cache[Cat], CatToIAnimal)
 
     def test_get_adapter_called_only_once_for_repeated_adapts(self):
         cat = Cat()
@@ -80,8 +80,8 @@ class TestAdapterCache(unittest.TestCase):
 
     def test_none_cached_when_no_adapter_exists(self):
         IAnimal.adapt_or_none(Fish(), interface_only=False)
-        self.assertIn(Fish, IAnimal._pi._adapter_cache)
-        self.assertIsNone(IAnimal._pi._adapter_cache[Fish])
+        self.assertIn(Fish, IAnimal._pi.adapter_cache)
+        self.assertIsNone(IAnimal._pi.adapter_cache[Fish])
 
     def test_get_adapter_called_only_once_for_repeated_none_results(self):
         fish = Fish()
@@ -91,16 +91,16 @@ class TestAdapterCache(unittest.TestCase):
         mock_get.assert_called_once()
 
     def test_clear_adapter_caches_clears_interface_cache(self):
-        IAnimal._pi._adapter_cache[Cat] = CatToIAnimal
+        IAnimal._pi.adapter_cache[Cat] = CatToIAnimal
         interface.clear_adapter_caches(IAnimal)
-        self.assertEqual(IAnimal._pi._adapter_cache, {})
+        self.assertEqual(len(IAnimal._pi.adapter_cache), 0)
 
     def test_clear_adapter_caches_on_child_clears_parent_cache(self):
         # IAnimal's cache should be cleared when IDog's adapters change,
         # because _get_adapter(IAnimal, ...) collects adapters from IAnimal.__subclasses__()
-        IAnimal._pi._adapter_cache[Hawk] = None
+        IAnimal._pi.adapter_cache[Hawk] = None
         interface.clear_adapter_caches(IDog)
-        self.assertNotIn(Hawk, IAnimal._pi._adapter_cache)
+        self.assertNotIn(Hawk, IAnimal._pi.adapter_cache)
 
     def test_parent_interface_finds_adapter_registered_on_child(self):
         adapted = IAnimal.adapt(Hawk(), interface_only=False)
@@ -108,20 +108,20 @@ class TestAdapterCache(unittest.TestCase):
 
     def test_parent_caches_adapter_found_via_child(self):
         IAnimal.adapt(Hawk(), interface_only=False)
-        self.assertIn(Hawk, IAnimal._pi._adapter_cache)
-        self.assertIs(IAnimal._pi._adapter_cache[Hawk], HawkToIDog)
+        self.assertIn(Hawk, IAnimal._pi.adapter_cache)
+        self.assertIs(IAnimal._pi.adapter_cache[Hawk], HawkToIDog)
 
     def test_register_type_clears_cache(self):
-        IAnimal._pi._adapter_cache[Iguana] = None
+        IAnimal._pi.adapter_cache[Iguana] = None
         IAnimal.register(Iguana)
-        self.assertNotIn(Iguana, IAnimal._pi._adapter_cache)
+        self.assertNotIn(Iguana, IAnimal._pi.adapter_cache)
 
     def test_register_adapter_clears_entire_cache(self):
         # Pre-populate cache with an unrelated entry
-        IAnimal._pi._adapter_cache[Fish] = None
+        IAnimal._pi.adapter_cache[Fish] = None
         # Registering any adapter should wipe the whole cache
         register_adapter(lambda obj: CatToIAnimal(obj), Iguana, IAnimal)
-        self.assertEqual(IAnimal._pi._adapter_cache, {})
+        self.assertEqual(len(IAnimal._pi.adapter_cache), 0)
 
     def test_stale_none_on_parent_cleared_when_adapter_registered_on_child(self):
         # Fresh types so no adapters are pre-registered
@@ -149,13 +149,13 @@ class TestAdapterCache(unittest.TestCase):
         # Prime a stale None on both parent and child: no adapter for Bicycle yet
         self.assertIsNone(IVehicle.adapt_or_none(Bicycle(), interface_only=False))
         self.assertIsNone(ICar.adapt_or_none(Bicycle(), interface_only=False))
-        self.assertIsNone(IVehicle._pi._adapter_cache[Bicycle])
-        self.assertIsNone(ICar._pi._adapter_cache[Bicycle])
+        self.assertIsNone(IVehicle._pi.adapter_cache[Bicycle])
+        self.assertIsNone(ICar._pi.adapter_cache[Bicycle])
 
         # Registering on the child must evict the stale entry from both caches
         register_adapter(BicycleToICar, Bicycle, ICar)
-        self.assertNotIn(Bicycle, IVehicle._pi._adapter_cache)
-        self.assertNotIn(Bicycle, ICar._pi._adapter_cache)
+        self.assertNotIn(Bicycle, IVehicle._pi.adapter_cache)
+        self.assertNotIn(Bicycle, ICar._pi.adapter_cache)
 
         # Parent can now adapt Bicycle via the child's adapter
         adapted = IVehicle.adapt(Bicycle(), interface_only=False)


### PR DESCRIPTION
Closes #121

This adds a cache to return an adapter from a class to an interface. In my testing of a project this reduced the time substantially.

This also attempts to purge adapters from the cache when a new classes or adapters are registered.

```
Without cache:
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
   137657    1.502    0.000   10.618    0.000 C:\Source\leapfrog-1\components\win64\lib\site-packages\pure_interface\interface.py:571(_get_adapter)

With cache:
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      284    0.003    0.000    0.024    0.000 C:\Source\leapfrog-1\components\win64\lib\site-packages\pure_interface\interface.py:585(_get_adapter)
```